### PR TITLE
fix: RequestSignatureListener should implements ListenerInterface

### DIFF
--- a/Security/Firewall/RequestSignatureListener.php
+++ b/Security/Firewall/RequestSignatureListener.php
@@ -4,10 +4,11 @@ namespace Rezzza\SecurityBundle\Security\Firewall;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 
 // Symfony < 4.3
 if (!class_exists(RequestEvent::class)) {
-    class RequestSignatureListener
+    class RequestSignatureListener implements ListenerInterface
     {
         use RequestSignatureListenerTrait;
 


### PR DESCRIPTION
`
Type error: Argument 1 passed to Symfony\\Bundle\\SecurityBundle\\Debug\\WrappedListener::__construct() must implement interface Symfony\\Component\\Security\\Http\\Firewall\\ListenerInterface, instance of Rezzza\\SecurityBundle\\Security\\Firewall\\RequestSignatureListener given
`